### PR TITLE
Use then_some to simplify splitting logic.

### DIFF
--- a/tokenizers/src/tokenizer/pre_tokenizer.rs
+++ b/tokenizers/src/tokenizer/pre_tokenizer.rs
@@ -87,11 +87,7 @@ impl PreTokenizedString {
                     .into_iter()
                     .filter_map(|split| {
                         let split: Split = split.into();
-                        if split.normalized.is_empty() {
-                            None
-                        } else {
-                            Some(split)
-                        }
+                        split.normalized.is_empty().then_some(split)
                     }),
             );
         }


### PR DESCRIPTION
It's more idiomatic and is available since Rust 1.62.